### PR TITLE
Fix member adding and removing issue

### DIFF
--- a/kubernetes-membership-scheme/src/main/java/org/wso2/carbon/membership/scheme/kubernetes/KubernetesMembershipScheme.java
+++ b/kubernetes-membership-scheme/src/main/java/org/wso2/carbon/membership/scheme/kubernetes/KubernetesMembershipScheme.java
@@ -1,18 +1,18 @@
 /*
- * Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+* Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
 
 package org.wso2.carbon.membership.scheme.kubernetes;
 
@@ -50,29 +50,25 @@ public class KubernetesMembershipScheme implements HazelcastMembershipScheme {
     private HazelcastCarbonClusterImpl carbonCluster;
 
     public KubernetesMembershipScheme(Map<String, Parameter> parameters, String primaryDomain, Config config,
-                                      HazelcastInstance primaryHazelcastInstance, List<ClusteringMessage> messageBuffer) {
+            HazelcastInstance primaryHazelcastInstance, List<ClusteringMessage> messageBuffer) {
         this.parameters = parameters;
         this.primaryHazelcastInstance = primaryHazelcastInstance;
         this.messageBuffer = messageBuffer;
         this.nwConfig = config.getNetworkConfig();
     }
 
-    @Override
-    public void setPrimaryHazelcastInstance(HazelcastInstance primaryHazelcastInstance) {
+    @Override public void setPrimaryHazelcastInstance(HazelcastInstance primaryHazelcastInstance) {
         this.primaryHazelcastInstance = primaryHazelcastInstance;
     }
 
-    @Override
-    public void setLocalMember(Member localMember) {
+    @Override public void setLocalMember(Member localMember) {
     }
 
-    @Override
-    public void setCarbonCluster(HazelcastCarbonClusterImpl hazelcastCarbonCluster) {
+    @Override public void setCarbonCluster(HazelcastCarbonClusterImpl hazelcastCarbonCluster) {
         this.carbonCluster = hazelcastCarbonCluster;
     }
 
-    @Override
-    public void init() throws ClusteringFault {
+    @Override public void init() throws ClusteringFault {
         try {
             log.info("Initializing kubernetes membership scheme...");
 
@@ -128,8 +124,7 @@ public class KubernetesMembershipScheme implements HazelcastMembershipScheme {
         return (String) kubernetesServicesParam.getValue();
     }
 
-    @Override
-    public void joinGroup() throws ClusteringFault {
+    @Override public void joinGroup() throws ClusteringFault {
         primaryHazelcastInstance.getCluster().addMembershipListener(new KubernetesMembershipSchemeListener());
     }
 
@@ -142,13 +137,13 @@ public class KubernetesMembershipScheme implements HazelcastMembershipScheme {
      */
     private class KubernetesMembershipSchemeListener implements MembershipListener {
 
-        @Override
-        public void memberAdded(MembershipEvent membershipEvent) {
+        @Override public void memberAdded(MembershipEvent membershipEvent) {
             Member member = membershipEvent.getMember();
             List<String> memberList = nwConfig.getJoin().getTcpIpConfig().setEnabled(true).getMembers();
             if (!memberList.contains(member.getSocketAddress().getAddress().getHostAddress())) {
                 nwConfig.getJoin().getTcpIpConfig().setEnabled(true).addMember(String.valueOf(member.getSocketAddress().getAddress().getHostAddress()));
             }
+
             // Send all cluster messages
             carbonCluster.memberAdded(member);
             log.info(String.format("Member joined: [UUID] %s, [Address] %s", member.getUuid(),
@@ -162,19 +157,16 @@ public class KubernetesMembershipScheme implements HazelcastMembershipScheme {
             log.info(String.format("Current member list: %s", nwConfig.getJoin().getTcpIpConfig().setEnabled(true).getMembers()));
         }
 
-        @Override
-        public void memberRemoved(MembershipEvent membershipEvent) {
+        @Override public void memberRemoved(MembershipEvent membershipEvent) {
             Member member = membershipEvent.getMember();
             carbonCluster.memberRemoved(member);
             log.info(String.format("Member left: [UUID] %s, [Address] %s", member.getUuid(),
                     member.getSocketAddress().toString()));
             nwConfig.getJoin().getTcpIpConfig().setEnabled(true).getMembers().remove(String.valueOf(member.getSocketAddress().getAddress().getHostAddress()));
             log.info(String.format("Current member list: %s", nwConfig.getJoin().getTcpIpConfig().setEnabled(true).getMembers()));
-
         }
 
-        @Override
-        public void memberAttributeChanged(MemberAttributeEvent memberAttributeEvent) {
+        @Override public void memberAttributeChanged(MemberAttributeEvent memberAttributeEvent) {
             if (log.isDebugEnabled()) {
                 log.debug(String.format("Member attribute changed: [Key] %s, [Value] %s", memberAttributeEvent.getKey(),
                         memberAttributeEvent.getValue()));

--- a/kubernetes-membership-scheme/src/main/java/org/wso2/carbon/membership/scheme/kubernetes/KubernetesMembershipScheme.java
+++ b/kubernetes-membership-scheme/src/main/java/org/wso2/carbon/membership/scheme/kubernetes/KubernetesMembershipScheme.java
@@ -114,7 +114,7 @@ public class KubernetesMembershipScheme implements HazelcastMembershipScheme {
             TcpIpConfig tcpIpConfig = nwConfig.getJoin().getTcpIpConfig();
             tcpIpConfig.setEnabled(true);
             initPodIpResolver();
-            Set <String> containerIPs = getK8sPodIpAddresses();
+            Set<String> containerIPs = getK8sPodIpAddresses();
             // if no IPs are found, can't initialize clustering
             if (containerIPs.isEmpty()) {
                 throw new KubernetesMembershipSchemeException("No member ips found, unable to initialize the "
@@ -122,7 +122,7 @@ public class KubernetesMembershipScheme implements HazelcastMembershipScheme {
             }
 
             for (String containerIP : containerIPs) {
-                if(!containerIP.equals(Inet4Address.getLocalHost().getHostAddress())) {
+                if (!containerIP.equals(Inet4Address.getLocalHost().getHostAddress())) {
                     tcpIpConfig.addMember(containerIP);
                     log.info("Member added to cluster configuration: [container-ip] " + containerIP);
                 }
@@ -164,8 +164,8 @@ public class KubernetesMembershipScheme implements HazelcastMembershipScheme {
         @Override public void memberAdded(MembershipEvent membershipEvent) {
             Member member = membershipEvent.getMember();
             TcpIpConfig tcpIpConfig = nwConfig.getJoin().getTcpIpConfig();
-            List <String> memberList = tcpIpConfig.getMembers();
-            if (!memberList.contains(member.getSocketAddress().getAddress().getHostAddress())){
+            List<String> memberList = tcpIpConfig.getMembers();
+            if (!memberList.contains(member.getSocketAddress().getAddress().getHostAddress())) {
                 tcpIpConfig.addMember(String.valueOf(member.getSocketAddress().getAddress().getHostAddress()));
             }
 
@@ -180,7 +180,7 @@ public class KubernetesMembershipScheme implements HazelcastMembershipScheme {
             }
             HazelcastUtil.sendMessagesToMember(messageBuffer, member, carbonCluster);
             if (log.isDebugEnabled()) {
-                log.debug(String.format("Current member list: %s",tcpIpConfig.getMembers()));
+                log.debug(String.format("Current member list: %s", tcpIpConfig.getMembers()));
             }
         }
 
@@ -188,21 +188,21 @@ public class KubernetesMembershipScheme implements HazelcastMembershipScheme {
             Member member = membershipEvent.getMember();
             carbonCluster.memberRemoved(member);
             TcpIpConfig tcpIpConfig = nwConfig.getJoin().getTcpIpConfig();
-            Set <String> containerIPs;
+            Set<String> containerIPs;
             String memberIp = member.getSocketAddress().getAddress().getHostAddress();
             try {
                 containerIPs = getK8sPodIpAddresses();
-                if (!containerIPs.contains(memberIp)){
+                if (!containerIPs.contains(memberIp)) {
                     tcpIpConfig.getMembers()
                             .remove(String.valueOf(member.getSocketAddress().getAddress().getHostAddress()));
                     log.info(String.format("Member left: [UUID] %s, [Address] %s", member.getUuid(),
                             member.getSocketAddress().toString()));
                     if (log.isDebugEnabled()) {
-                        log.debug(String.format("Current member list: %s",tcpIpConfig.getMembers()));
+                        log.debug(String.format("Current member list: %s", tcpIpConfig.getMembers()));
                     }
                 }
             } catch (KubernetesMembershipSchemeException e) {
-                log.error("Could not remove member: "+ memberIp,e);
+                log.error("Could not remove member: " + memberIp, e);
             }
         }
 

--- a/kubernetes-membership-scheme/src/main/java/org/wso2/carbon/membership/scheme/kubernetes/KubernetesMembershipScheme.java
+++ b/kubernetes-membership-scheme/src/main/java/org/wso2/carbon/membership/scheme/kubernetes/KubernetesMembershipScheme.java
@@ -79,7 +79,6 @@ public class KubernetesMembershipScheme implements HazelcastMembershipScheme {
      *
      * @return IP addresses of the current pods. Returns null upon any error querying K8S.
      */
-
     private Set<String> getK8sPodIpAddresses() throws KubernetesMembershipSchemeException {
         Set<String> containerIps = podIpResolver.resolveAddresses();
         if (containerIps != null) {
@@ -93,7 +92,6 @@ public class KubernetesMembershipScheme implements HazelcastMembershipScheme {
      * Initiates the Pod IP resolver.
      * Uses the DNS based pod IP resolver or the API based pod IP resolver.
      */
-
     private void initPodIpResolver() throws KubernetesMembershipSchemeException {
         String useDns = System.getenv(Constants.USE_DNS);
         if (StringUtils.isEmpty(useDns)) {

--- a/kubernetes-membership-scheme/src/main/java/org/wso2/carbon/membership/scheme/kubernetes/KubernetesMembershipScheme.java
+++ b/kubernetes-membership-scheme/src/main/java/org/wso2/carbon/membership/scheme/kubernetes/KubernetesMembershipScheme.java
@@ -117,7 +117,7 @@ public class KubernetesMembershipScheme implements HazelcastMembershipScheme {
             Set<String> containerIPs = getK8sPodIpAddresses();
             // if no IPs are found, can't initialize clustering
             if (containerIPs.isEmpty()) {
-                throw new KubernetesMembershipSchemeException("No member ips found, unable to initialize the "
+                throw new KubernetesMembershipSchemeException("No members found, unable to initialize the "
                         + "Kubernetes membership scheme");
             }
 

--- a/kubernetes-membership-scheme/src/main/java/org/wso2/carbon/membership/scheme/kubernetes/KubernetesMembershipScheme.java
+++ b/kubernetes-membership-scheme/src/main/java/org/wso2/carbon/membership/scheme/kubernetes/KubernetesMembershipScheme.java
@@ -141,7 +141,8 @@ public class KubernetesMembershipScheme implements HazelcastMembershipScheme {
             Member member = membershipEvent.getMember();
             List<String> memberList = nwConfig.getJoin().getTcpIpConfig().setEnabled(true).getMembers();
             if (!memberList.contains(member.getSocketAddress().getAddress().getHostAddress())) {
-                nwConfig.getJoin().getTcpIpConfig().setEnabled(true).addMember(String.valueOf(member.getSocketAddress().getAddress().getHostAddress()));
+                nwConfig.getJoin().getTcpIpConfig().setEnabled(true)
+                        .addMember(String.valueOf(member.getSocketAddress().getAddress().getHostAddress()));
             }
 
             // Send all cluster messages
@@ -154,7 +155,10 @@ public class KubernetesMembershipScheme implements HazelcastMembershipScheme {
             } catch (InterruptedException ignored) {
             }
             HazelcastUtil.sendMessagesToMember(messageBuffer, member, carbonCluster);
-            log.info(String.format("Current member list: %s", nwConfig.getJoin().getTcpIpConfig().setEnabled(true).getMembers()));
+            if (log.isInfoEnabled()) {
+                log.info(String.format("Current member list: %s",
+                        nwConfig.getJoin().getTcpIpConfig().setEnabled(true).getMembers()));
+            }
         }
 
         @Override public void memberRemoved(MembershipEvent membershipEvent) {
@@ -162,8 +166,12 @@ public class KubernetesMembershipScheme implements HazelcastMembershipScheme {
             carbonCluster.memberRemoved(member);
             log.info(String.format("Member left: [UUID] %s, [Address] %s", member.getUuid(),
                     member.getSocketAddress().toString()));
-            nwConfig.getJoin().getTcpIpConfig().setEnabled(true).getMembers().remove(String.valueOf(member.getSocketAddress().getAddress().getHostAddress()));
-            log.info(String.format("Current member list: %s", nwConfig.getJoin().getTcpIpConfig().setEnabled(true).getMembers()));
+            nwConfig.getJoin().getTcpIpConfig().setEnabled(true)
+                    .getMembers().remove(String.valueOf(member.getSocketAddress().getAddress().getHostAddress()));
+            if (log.isInfoEnabled()) {
+                log.info(String.format("Current member list: %s",
+                        nwConfig.getJoin().getTcpIpConfig().setEnabled(true).getMembers()));
+            }
         }
 
         @Override public void memberAttributeChanged(MemberAttributeEvent memberAttributeEvent) {

--- a/kubernetes-membership-scheme/src/main/java/org/wso2/carbon/membership/scheme/kubernetes/KubernetesMembershipScheme.java
+++ b/kubernetes-membership-scheme/src/main/java/org/wso2/carbon/membership/scheme/kubernetes/KubernetesMembershipScheme.java
@@ -1,18 +1,18 @@
 /*
-* Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package org.wso2.carbon.membership.scheme.kubernetes;
 
@@ -50,25 +50,29 @@ public class KubernetesMembershipScheme implements HazelcastMembershipScheme {
     private HazelcastCarbonClusterImpl carbonCluster;
 
     public KubernetesMembershipScheme(Map<String, Parameter> parameters, String primaryDomain, Config config,
-            HazelcastInstance primaryHazelcastInstance, List<ClusteringMessage> messageBuffer) {
+                                      HazelcastInstance primaryHazelcastInstance, List<ClusteringMessage> messageBuffer) {
         this.parameters = parameters;
         this.primaryHazelcastInstance = primaryHazelcastInstance;
         this.messageBuffer = messageBuffer;
         this.nwConfig = config.getNetworkConfig();
     }
 
-    @Override public void setPrimaryHazelcastInstance(HazelcastInstance primaryHazelcastInstance) {
+    @Override
+    public void setPrimaryHazelcastInstance(HazelcastInstance primaryHazelcastInstance) {
         this.primaryHazelcastInstance = primaryHazelcastInstance;
     }
 
-    @Override public void setLocalMember(Member localMember) {
+    @Override
+    public void setLocalMember(Member localMember) {
     }
 
-    @Override public void setCarbonCluster(HazelcastCarbonClusterImpl hazelcastCarbonCluster) {
+    @Override
+    public void setCarbonCluster(HazelcastCarbonClusterImpl hazelcastCarbonCluster) {
         this.carbonCluster = hazelcastCarbonCluster;
     }
 
-    @Override public void init() throws ClusteringFault {
+    @Override
+    public void init() throws ClusteringFault {
         try {
             log.info("Initializing kubernetes membership scheme...");
 
@@ -124,7 +128,8 @@ public class KubernetesMembershipScheme implements HazelcastMembershipScheme {
         return (String) kubernetesServicesParam.getValue();
     }
 
-    @Override public void joinGroup() throws ClusteringFault {
+    @Override
+    public void joinGroup() throws ClusteringFault {
         primaryHazelcastInstance.getCluster().addMembershipListener(new KubernetesMembershipSchemeListener());
     }
 
@@ -137,9 +142,13 @@ public class KubernetesMembershipScheme implements HazelcastMembershipScheme {
      */
     private class KubernetesMembershipSchemeListener implements MembershipListener {
 
-        @Override public void memberAdded(MembershipEvent membershipEvent) {
+        @Override
+        public void memberAdded(MembershipEvent membershipEvent) {
             Member member = membershipEvent.getMember();
-
+            List<String> memberList = nwConfig.getJoin().getTcpIpConfig().setEnabled(true).getMembers();
+            if (!memberList.contains(member.getSocketAddress().getAddress().getHostAddress())) {
+                nwConfig.getJoin().getTcpIpConfig().setEnabled(true).addMember(String.valueOf(member.getSocketAddress().getAddress().getHostAddress()));
+            }
             // Send all cluster messages
             carbonCluster.memberAdded(member);
             log.info(String.format("Member joined: [UUID] %s, [Address] %s", member.getUuid(),
@@ -150,16 +159,22 @@ public class KubernetesMembershipScheme implements HazelcastMembershipScheme {
             } catch (InterruptedException ignored) {
             }
             HazelcastUtil.sendMessagesToMember(messageBuffer, member, carbonCluster);
+            log.info(String.format("Current member list: %s", nwConfig.getJoin().getTcpIpConfig().setEnabled(true).getMembers()));
         }
 
-        @Override public void memberRemoved(MembershipEvent membershipEvent) {
+        @Override
+        public void memberRemoved(MembershipEvent membershipEvent) {
             Member member = membershipEvent.getMember();
             carbonCluster.memberRemoved(member);
             log.info(String.format("Member left: [UUID] %s, [Address] %s", member.getUuid(),
                     member.getSocketAddress().toString()));
+            nwConfig.getJoin().getTcpIpConfig().setEnabled(true).getMembers().remove(String.valueOf(member.getSocketAddress().getAddress().getHostAddress()));
+            log.info(String.format("Current member list: %s", nwConfig.getJoin().getTcpIpConfig().setEnabled(true).getMembers()));
+
         }
 
-        @Override public void memberAttributeChanged(MemberAttributeEvent memberAttributeEvent) {
+        @Override
+        public void memberAttributeChanged(MemberAttributeEvent memberAttributeEvent) {
             if (log.isDebugEnabled()) {
                 log.debug(String.format("Member attribute changed: [Key] %s, [Value] %s", memberAttributeEvent.getKey(),
                         memberAttributeEvent.getValue()));


### PR DESCRIPTION
## Purpose
> Fixes #17 

## Goals
> Remove the deleted pods IP Addresses from the members IP lists
> Add the respawned pods IP Addresses to the members IP lists

## Approach
> Get the deleted pod's IP address and remove it from the member list
> Check whether the newly created pod's IP is in the member list and if not add it to the member list

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Security checks
> Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
> Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> JDK 1.8u144
> OS Ubuntu 18.04
> Tested environment - AWS EKS
> Kubectl - 1.14

## Automation tests
N/A