### PR TITLE
Update maven central repo url http -> https

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -191,7 +191,7 @@
             <id>central</id>
             <name>Maven Central Repository</name>
             <layout>default</layout>
-            <url>http://repo1.maven.org/maven2</url>
+            <url>https://repo1.maven.org/maven2</url>
             <releases>
                 <enabled>true</enabled>
                 <updatePolicy>daily</updatePolicy>


### PR DESCRIPTION
## Purpose
Recently maven restricted to have HTTPS in central repository URL.
This PR is to commit the change.


Tested with new local m2 repo and mvn clean install

```
[INFO] --- maven-bundle-plugin:3.5.0:install (default-install) @ kubernetes-membership-scheme ---
[INFO] Local OBR update disabled (enable with -DobrRepository)
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for WSO2 Kubernetes Artifacts 1.0.8-SNAPSHOT:
[INFO] 
[INFO] WSO2 Kubernetes Artifacts .......................... SUCCESS [  0.850 s]
[INFO] WSO2 Kubernetes Membership Scheme .................. SUCCESS [02:11 min]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  02:14 min
[INFO] Finished at: 2021-07-16T13:52:58+05:30
[INFO] ------------------------------------------------------------------------

```