### PR TITLE
Update jackson dependency version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -302,8 +302,8 @@
         <axis2.version>1.6.1-wso2v40</axis2.version>
         <commons.logging.version>1.1.1</commons.logging.version>
         <hazelcast.version>3.12.2.wso2v1</hazelcast.version>
-	<jackson.version>2.13.2</jackson.version>
-	<jackson.databind.version>2.13.2.1</jackson.databind.version>
+	<jackson.version>2.13.4</jackson.version>
+	<jackson.databind.version>2.13.4.2</jackson.databind.version>
         <ppaas.version>4.1.5</ppaas.version>
         <mockserver.version>3.10.4</mockserver.version>
         <testng.version>6.9.9</testng.version>


### PR DESCRIPTION
## Purpose
jackson-databind version 2.13.2 is vulnerable to CVE-2022-42004. This was detected during an IS 5.11 docker image scan.